### PR TITLE
[Refactor/#78] 검색화면 추천 섹션 ui 수정

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -59,15 +59,15 @@ export default function SearchPage() {
 
 	return (
 		<>
-			<main className="flex w-full justify-center pt-20">
+			<main className="flex w-full flex-col items-center pt-20">
 				<div className="flex w-[1040px] flex-col items-center gap-20 px-20 pt-48 pb-20">
-					{/* A. 검색 및 필터링 섹션 */}
+					{/* 검색 및 필터링 섹션 */}
 					<section className="flex flex-col items-center justify-start gap-10 self-stretch">
 						<SearchBar value={searchTerm} onChange={handleSearchChange} />
 						<TagList selectedTag={selectedTag} onTagSelect={handleTagSelect} />
 					</section>
 
-					{/* B. 검색 결과 섹션 */}
+					{/* 검색 결과 섹션 */}
 					{(debouncedSearchTerm.trim().length >= 2 ||
 						selectedTag !== "전체") && (
 						<SearchResultsSection
@@ -77,12 +77,16 @@ export default function SearchPage() {
 							searchResults={searchResults}
 						/>
 					)}
-
-					{/* C. 추천 용어 섹션 */}
-					{debouncedSearchTerm.trim().length < 2 && selectedTag === "전체" && (
-						<RecommendedTermsSection />
-					)}
 				</div>
+
+				{/* 추천 용어 섹션 */}
+				{debouncedSearchTerm.trim().length < 2 && selectedTag === "전체" && (
+					<div className="flex w-full justify-center pb-40">
+						<div className="w-content px-20">
+							<RecommendedTermsSection />
+						</div>
+					</div>
+				)}
 			</main>
 		</>
 	);

--- a/src/components/search/RecommendedTermsSection.tsx
+++ b/src/components/search/RecommendedTermsSection.tsx
@@ -31,11 +31,11 @@ export default function RecommendedTermsSection() {
 		: recommendedTerms.slice(0, 3);
 
 	return (
-		<section className="flex flex-col items-start justify-start gap-5 self-stretch">
-			<div className="self-stretch font-['Pretendard'] text-sm leading-5 font-semibold text-gray-500">
+		<section className="flex flex-col items-center justify-start gap-5 self-stretch">
+			<div className="self-stretch text-left font-['Pretendard'] text-sm leading-5 font-semibold text-gray-500">
 				추천 용어
 			</div>
-			<div className="inline-flex flex-wrap items-start justify-start gap-6 self-stretch">
+			<div className="inline-flex flex-wrap items-start justify-center gap-6 self-stretch">
 				{displayedRecommendedTerms.map((term, index) => (
 					<RecommendedTermCard
 						key={index}


### PR DESCRIPTION
## ✨ 작업 개요

<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
검색화면 추천 섹션 가운데 정렬
## 📌 관련 이슈

- close #78 

## ✅ 작업 내용
검색화면 추천 섹션 가운데 정렬

## 📷 UI 스크린샷 (해당 시)

<!-- 전/후 비교 이미지 등 첨부 -->

## 💬 기타 사항

<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일/레이아웃**
  * 검색 페이지의 레이아웃을 수직 컬럼 방식으로 개선하고 항목 중앙 정렬 적용
  * 추천 용어 섹션을 페이지 하단으로 이동하며 중앙 정렬 강화
  * 검색 결과 섹션의 정렬 및 표시 방식 개선

* **개선사항**
  * 검색 결과 섹션에서 추가 정보(검색어, 태그, 검색 상태) 표시 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->